### PR TITLE
Preventing dynamisWaitxDay from refreshing unintentionally.

### DIFF
--- a/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
+++ b/scripts/zones/Dynamis-Bastok/bcnms/dynamis_bastok.lua
@@ -16,7 +16,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaBastok]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
+++ b/scripts/zones/Dynamis-Beaucedine/bcnms/dynamis_beaucedine.lua
@@ -15,7 +15,13 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaBeaucedine]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_Buburimu.lua
+++ b/scripts/zones/Dynamis-Buburimu/bcnms/dynamis_Buburimu.lua
@@ -19,7 +19,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaBuburimu]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
+++ b/scripts/zones/Dynamis-Jeuno/bcnms/dynamis_jeuno.lua
@@ -16,7 +16,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaJeuno]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Qufim/bcnms/dynamis_Qufim.lua
+++ b/scripts/zones/Dynamis-Qufim/bcnms/dynamis_Qufim.lua
@@ -19,7 +19,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaQufim]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
+++ b/scripts/zones/Dynamis-San_dOria/bcnms/dynamis_sandoria.lua
@@ -16,7 +16,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaSandoria]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_Tavnazia.lua
+++ b/scripts/zones/Dynamis-Tavnazia/bcnms/dynamis_Tavnazia.lua
@@ -18,7 +18,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaTavnazia]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_Valkurm.lua
+++ b/scripts/zones/Dynamis-Valkurm/bcnms/dynamis_Valkurm.lua
@@ -38,7 +38,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaValkurm]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
+++ b/scripts/zones/Dynamis-Windurst/bcnms/dynamis_windurst.lua
@@ -16,7 +16,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaWindurst]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 

--- a/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
+++ b/scripts/zones/Dynamis-Xarcabard/bcnms/dynamis_xarcabard.lua
@@ -16,7 +16,12 @@ end;
 function onBcnmEnter(player,instance)
 	
 	player:setVar("DynamisID",GetServerVariable("[DynaXarcabard]UniqueID"));
-	player:setVar("dynaWaitxDay",os.time());
+	local realDay = os.time();
+    local dynaWaitxDay = player:getVar("dynaWaitxDay");
+
+    if ((dynaWaitxDay + (BETWEEN_2DYNA_WAIT_TIME * 24 * 60 * 60)) < realDay) then
+		player:setVar("dynaWaitxDay",realDay);
+	end
 	
 end;
 


### PR DESCRIPTION
Upon entering dynamis, this change prevents dynamisWaitxDay from udpating if its current value is less than 24 hours (based on current value of BETWEEN_2DYNA_WAIT_TIME).

So, now a player's wait time will only be updated the first time they enter.